### PR TITLE
proxy: Add trailing newline to AsScriptEnvironment

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -75,7 +75,7 @@ func (s *Settings) AsScriptEnvironment() string {
 	addLine(https_proxy, s.Https)
 	addLine(ftp_proxy, s.Ftp)
 	addLine(no_proxy, s.FullNoProxy())
-	return strings.Join(lines, "\n")
+	return fmt.Sprintf("%s\n", strings.Join(lines, "\n"))
 }
 
 // AsEnvironmentValues returns a slice of strings of the format "key=value"

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -130,7 +130,8 @@ func (s *proxySuite) TestAsScriptEnvironmentOneValue(c *gc.C) {
 	}
 	expected := `
 export http_proxy=some-value
-export HTTP_PROXY=some-value`[1:]
+export HTTP_PROXY=some-value
+`[1:]
 	c.Assert(proxies.AsScriptEnvironment(), gc.Equals, expected)
 }
 
@@ -149,7 +150,8 @@ export HTTPS_PROXY=special
 export ftp_proxy=who uses this?
 export FTP_PROXY=who uses this?
 export no_proxy=10.0.3.1,localhost
-export NO_PROXY=10.0.3.1,localhost`[1:]
+export NO_PROXY=10.0.3.1,localhost
+`[1:]
 	c.Assert(proxies.AsScriptEnvironment(), gc.Equals, expected)
 }
 


### PR DESCRIPTION
This makes /etc/juju-proxy.conf be a properly formatted shell script
with a trailing new line (makes it easier to read).

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>